### PR TITLE
[feat/#134] 마이페이지 API 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,12 @@ const nextConfig: NextConfig = {
 				protocol: "https",
 				hostname: "shopping-phinf.pstatic.net",
 			},
+			{
+				protocol: 'https',
+				hostname: 'umc-pharmquest.s3.ap-northeast-2.amazonaws.com',
+				port: '',
+				pathname: '/**',
+			  },
 		],
 		domains: process.env.NEXT_PUBLIC_IMAGE_DOMAIN
 			? [process.env.NEXT_PUBLIC_IMAGE_DOMAIN]

--- a/src/components/common/Search.tsx
+++ b/src/components/common/Search.tsx
@@ -63,6 +63,16 @@ const Search = () => {
     setIsSearchModalOpen(false);
   }, [searchUrl])
 
+  useEffect(() => {
+    // pathname이 /supplements이고 query가 비어있을 때 (헤더에서 해외인기영양제 클릭 시)
+    if (router.pathname === '/supplements' && Object.keys(router.query).length === 0) {
+      setCountryValue("");
+      setCountryText("전체");
+      setSearchText("");  // 검색어 초기화
+      setIsSearchModalOpen(false);
+    }
+  }, [router.pathname, router.query]);
+
   return (
     <div className="w-full flex items-center gap-4">
       {/* 검색창 */}

--- a/src/components/common/SupplementCard.tsx
+++ b/src/components/common/SupplementCard.tsx
@@ -38,7 +38,7 @@ export default function SupplementCard({
   onBookmarkToggle,
 }: SupplementCardProps) {
   const [bookmarked, setBookmarked] = useState(scrapped);
-  const [imgSrc, setImgSrc] = useState("");
+  const [imgSrc, setImgSrc] = useState(src || "/images/no_image.webp");
 
   useEffect(() => {
     setImgSrc(src || "/images/no_image.webp");

--- a/src/components/common/SupplementCard.tsx
+++ b/src/components/common/SupplementCard.tsx
@@ -19,9 +19,9 @@ interface ScrapResponse {
 interface SupplementCardProps {
   id: number;
   country: string;
-  title: string;
-  tags: string[];
-  isBookmarked?: boolean;
+  productName: string;
+  categories: string[];
+  scrapped?: boolean;
   width?: number;
   src?: string;
   onBookmarkToggle?: (id: number) => void;
@@ -30,14 +30,14 @@ interface SupplementCardProps {
 export default function SupplementCard({
   id,
   country,
-  title,
-  tags,
-  isBookmarked = false,
+  productName,
+  categories,
+  scrapped = false,
   width = 160,
   src = "/images/no_image.webp",
   onBookmarkToggle,
 }: SupplementCardProps) {
-  const [bookmarked, setBookmarked] = useState(isBookmarked);
+  const [bookmarked, setBookmarked] = useState(scrapped);
   const [imgSrc, setImgSrc] = useState("");
 
   useEffect(() => {
@@ -45,8 +45,8 @@ export default function SupplementCard({
   }, [src]);
 
   useEffect(() => {
-    setBookmarked(isBookmarked);
-  }, [isBookmarked]);
+    setBookmarked(scrapped);
+  }, [scrapped]);
   
   // const handleBookmarkClick = (event: React.MouseEvent<HTMLButtonElement>) => {
   //   event.stopPropagation();
@@ -98,7 +98,7 @@ export default function SupplementCard({
         {/* 이미지 */}
         <Image
           src={imgSrc || "/images/no_image.webp"}
-          alt={title || "이미지"}
+          alt={productName || "이미지"}
           className="absolute inset-0 w-full h-full object-cover rounded-lg"
           onError={() => setImgSrc("/images/no_image.webp")} // 이미지 로드 실패 시 대체 이미지 설정
           width={width}
@@ -131,15 +131,15 @@ export default function SupplementCard({
           </span>
           <span
             className="text-black text-base font-semibold leading-normal truncate overflow-hidden text-ellipsis"
-            title={title}
+            title={productName}
           >
-            {title}
+            {productName}
           </span>
         </div>
 
         {/* 태그 영역 */}
         <div className="flex flex-nowrap gap-1.5 overflow-hidden overflow-x-auto scrollbar-hide whitespace-nowrap">
-          {tags.map((tag, idx) => (
+          {categories.map((tag, idx) => (
             <div
               key={idx}
               className="px-2 py-0.5 bg-primary-50 rounded text-subhead2-sb text-gray-500 flex items-center"

--- a/src/components/common/SupplementCard.tsx
+++ b/src/components/common/SupplementCard.tsx
@@ -24,6 +24,7 @@ interface SupplementCardProps {
   isBookmarked?: boolean;
   width?: number;
   src?: string;
+  onBookmarkToggle?: (id: number) => void;
 }
 
 export default function SupplementCard({
@@ -34,6 +35,7 @@ export default function SupplementCard({
   isBookmarked = false,
   width = 160,
   src = "/images/no_image.webp",
+  onBookmarkToggle,
 }: SupplementCardProps) {
   const [bookmarked, setBookmarked] = useState(isBookmarked);
   const [imgSrc, setImgSrc] = useState("");
@@ -65,6 +67,7 @@ export default function SupplementCard({
         setBookmarked(!bookmarked);
         console.log("스크랩id=", id);
         console.log("스크랩data=", response);
+        onBookmarkToggle?.(id);
       } else {
         alert(response.data.message);
       }

--- a/src/pages/mypage/components/PharmacysCard.tsx
+++ b/src/pages/mypage/components/PharmacysCard.tsx
@@ -19,8 +19,8 @@ interface PharmacysCardProps {
 }
 
 const PharmacysCard: React.FC<PharmacysCardProps> = ({
-  name = "다나아약국",
-  region = "서울 중구 중앙동",
+  name,
+  region,
   img_url,
   latitude,
   longitude,

--- a/src/pages/mypage/components/PharmacysCard.tsx
+++ b/src/pages/mypage/components/PharmacysCard.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import { BookmarkIcon } from "@public/svgs";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useQuery } from "@tanstack/react-query";
 import { axiosInstance } from "@/apis/axios-instance";
 import axios from "axios";
 

--- a/src/pages/mypage/components/PharmacysCard.tsx
+++ b/src/pages/mypage/components/PharmacysCard.tsx
@@ -47,9 +47,9 @@ const PharmacysCard: React.FC<PharmacysCardProps> = ({
 
       // 성공 메시지 표시
       if (data.code === "PHARMACY201") {
-        console.log("약국이 스크랩되었습니다.");
+        console.log(`${name} 스크랩 완`);
       } else if (data.code === "PHARMACY202") {
-        console.log("약국 스크랩이 해제되었습니다.");
+        console.log(`${name} 스크랩 해제 완`);
       }
 
       // 약국 목록 데이터 갱신

--- a/src/pages/mypage/components/PharmacysCard.tsx
+++ b/src/pages/mypage/components/PharmacysCard.tsx
@@ -1,15 +1,21 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import { BookmarkIcon } from "@public/svgs";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
+import { axiosInstance } from "@/apis/axios-instance";
+import axios from "axios";
+
 interface PharmacysCardProps {
   name: string;
   region: string;
   img_url: string;
   latitude: number;
   longitude: number;
+  isScrapped: boolean;
   place_id: string;
   isBookmarked?: boolean;
-  onBookmarkToggle?: () => void;
+  onBookmarkToggle?: (place_id: string) => void;
 }
 
 const PharmacysCard: React.FC<PharmacysCardProps> = ({
@@ -18,16 +24,61 @@ const PharmacysCard: React.FC<PharmacysCardProps> = ({
   img_url,
   latitude,
   longitude,
-  isBookmarked = false,
+  isScrapped,
+  place_id,
   onBookmarkToggle,
 }) => {
-  const [isBookmark, setIsBookmark] = useState(isBookmarked);
+  const [bookmarked, setBookmarked] = useState(isScrapped);
   const [src, setSrc] = useState(img_url || "/images/no_image.webp"); // 기본 이미지 설정
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    setBookmarked(isScrapped);
+  }, [isScrapped]);
+
+  const { mutate: toggleScrap } = useMutation({
+    mutationFn: async () => {
+      const response = await axiosInstance.patch(`/pharmacy/${place_id}`);
+      return response.data;
+    },
+    onSuccess: (data) => {
+      // 스크랩 상태 토글
+      setBookmarked(prev => !prev);
+
+      // 성공 메시지 표시
+      if (data.code === "PHARMACY201") {
+        console.log("약국이 스크랩되었습니다.");
+      } else if (data.code === "PHARMACY202") {
+        console.log("약국 스크랩이 해제되었습니다.");
+      }
+
+      // 약국 목록 데이터 갱신
+      queryClient.invalidateQueries({ 
+        queryKey: ["mypagePharmacys"] 
+      });
+      
+      
+      if (onBookmarkToggle) {
+        onBookmarkToggle(place_id);
+      }
+    },
+    onError: (error) => {
+      // 에러 메시지 처리
+      if (axios.isAxiosError(error)) {
+        const errorMessage = error.response?.data?.message || "스크랩 처리 중 오류가 발생했습니다.";
+        console.log(errorMessage);
+        
+        // 스크랩 상태 원복
+        setBookmarked(isScrapped);
+      }
+    },
+  });
 
   const handleBookmark = (e: React.MouseEvent) => {
     e.stopPropagation(); // 클릭 이벤트 전파 방지
-    setIsBookmark((prev) => !prev);
-    if (onBookmarkToggle) onBookmarkToggle();
+    // setBookmarked((prev) => !prev);
+    // if (onBookmarkToggle) onBookmarkToggle();
+    toggleScrap();
   };
 
   return (
@@ -44,8 +95,8 @@ const PharmacysCard: React.FC<PharmacysCardProps> = ({
       >
         <BookmarkIcon
           className="md:w-[30px] w-6 cursor-pointer"
-          stroke={isBookmark ? "#FFD755" : "#707070"}
-          fill={isBookmark ? "#FFD755" : "none"}
+          stroke={bookmarked ? "#FFD755" : "#707070"}
+          fill={bookmarked ? "#FFD755" : "none"}
         />
       </button>
 

--- a/src/pages/mypage/components/PharmacysCard.tsx
+++ b/src/pages/mypage/components/PharmacysCard.tsx
@@ -2,22 +2,27 @@ import React, { useState } from "react";
 import Image from "next/image";
 import { BookmarkIcon } from "@public/svgs";
 interface PharmacysCardProps {
-  pharmacyName?: string;
-  location?: string;
-  imageUrl?: string;
+  name: string;
+  region: string;
+  img_url: string;
+  latitude: number;
+  longitude: number;
+  place_id: string;
   isBookmarked?: boolean;
   onBookmarkToggle?: () => void;
 }
 
 const PharmacysCard: React.FC<PharmacysCardProps> = ({
-  pharmacyName = "다나아약국",
-  location = "서울 중구 중앙동",
-  imageUrl,
+  name = "다나아약국",
+  region = "서울 중구 중앙동",
+  img_url,
+  latitude,
+  longitude,
   isBookmarked = false,
   onBookmarkToggle,
 }) => {
   const [isBookmark, setIsBookmark] = useState(isBookmarked);
-  const [src, setSrc] = useState(imageUrl || "/images/no_image.webp"); // 기본 이미지 설정
+  const [src, setSrc] = useState(img_url || "/images/no_image.webp"); // 기본 이미지 설정
 
   const handleBookmark = (e: React.MouseEvent) => {
     e.stopPropagation(); // 클릭 이벤트 전파 방지
@@ -63,8 +68,8 @@ const PharmacysCard: React.FC<PharmacysCardProps> = ({
 
       {/* ✅ 약국 정보 */}
       <div className="ml-4 flex-1 flex flex-col justify-start self-start gap-y-1 sm:gap-y-2">
-        <div className="text-gray-600 text-subhead1-sb">{pharmacyName}</div>
-        <div className="text-gray-400 text-body1-r">{location}</div>
+        <div className="text-gray-600 text-subhead1-sb">{name}</div>
+        <div className="text-gray-400 text-body1-r">{region}</div>
       </div>
     </div>
   );

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -250,13 +250,8 @@ const MyPage: React.FC<MyPageProps> = ({
           </Link>
         </div>
         {supplements.length > 0 ? (
-        // {supplementsData?.result?.content && supplementsData.result.content.length > 0 ? (
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-            {/* {supplements.map((supplement) => (
-              <SupplementCard key={supplement.id} {...supplement} />
-            ))} */}
             {supplements.slice(0, 10).map((supplement) => (
-            // {supplementsData?.result.content.slice(0, 10).map((supplement) => (
               <SupplementCard key={supplement.id}
                               id={supplement.id}
                               country={supplement.country}

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -4,8 +4,10 @@ import MedicineCard from "@/components/common/MedicineCard";
 import PharmacysCard from "./components/PharmacysCard";
 import SupplementCard from "@/components/common/SupplementCard";
 import useAuthStore from "@/store/useAuthStore";
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
+import { axiosInstance } from "@/apis/axios-instance";
+import { useQuery } from "@tanstack/react-query";
 
 interface Medicine {
   id: number;
@@ -22,20 +24,63 @@ interface Pharmacy {
   location: string;
 }
 
-interface Supplement {
-  id: number;
-  country: string;
-  title: string;
-  tags: string[];
-  isBookmarked: boolean;
+interface SupplementResponse {
+  code: string;
+  message: string;
+  result: {
+    totalElements: number;
+    totalPages: number;
+    size: number;
+    content: {
+      id: number;
+      name: string;
+      country: string;
+      productName: string;
+      image: string;
+      brand: string;
+      categories: string[];
+      scrapped: boolean;
+    }[];
+    number: number;
+    numberOfElements: number;
+    first: boolean;
+    last: boolean;
+    empty: boolean;
+    sort: {
+      empty: boolean;
+      sorted: boolean;
+      unsorted: boolean;
+    };
+    pageable: {
+      offset: number;
+      sort: {
+        empty: boolean;
+        sorted: boolean;
+        unsorted: boolean;
+      };
+      paged: boolean;
+      pageNumber: number;
+      pageSize: number;
+      unpaged: boolean;
+    };
+  };
+  isSuccess: boolean;
 }
+
+// interface Supplement {
+//   id: number;
+//   country: string;
+//   title: string;
+//   tags: string[];
+//   isBookmarked: boolean;
+// }
 
 interface MyPageProps {
   userName: string;
   userEmail: string;
   medicines?: Medicine[];
   pharmacys?: Pharmacy[];
-  supplements?: Supplement[];
+  // supplements?: Supplement[];
 }
 
 const MyPage: React.FC<MyPageProps> = ({
@@ -50,11 +95,14 @@ const MyPage: React.FC<MyPageProps> = ({
     { id: 3, pharmacyName: "온누리약국", status: true, closingTime: "19:00", distance: "700m", location: "서울 강남구 논현동" },
     { id: 4, pharmacyName: "튼튼약국", status: false, closingTime: "17:00", distance: "600m", location: "서울 종로구 종로3가" },
   ],
-   supplements = [
-    { id: 1, country: "미국", title: "네이처메이드", tags: ["면역력강화", "피부건강"], isBookmarked: true },
-    { id: 2, country: "한국", title: "홍삼정", tags: ["면역력", "활력"], isBookmarked: false },
-    { id: 3, country: "한국", title: "홍삼정", tags: ["면역력", "활력"], isBookmarked: false },
-  ],
+  // supplements = [
+  //   { id: 1, country: "미국", title: "네이처메이드", tags: ["면역력강화", "피부건강"], isBookmarked: true },
+  //   { id: 2, country: "한국", title: "홍삼정", tags: ["면역력", "활력"], isBookmarked: false },
+  //   { id: 3, country: "한국", title: "홍삼정", tags: ["면역력", "활력"], isBookmarked: false },
+  //   { id: 4, country: "미국", title: "네이처메이드", tags: ["면역력강화", "피부건강"], isBookmarked: true },
+  //   { id: 5, country: "한국", title: "홍삼정", tags: ["면역력", "활력"], isBookmarked: false },
+  //   { id: 6, country: "한국", title: "홍삼정", tags: ["면역력", "활력"], isBookmarked: false },
+  // ],
 }) => {
 
   const router = useRouter();
@@ -70,6 +118,31 @@ const MyPage: React.FC<MyPageProps> = ({
       router.push("/login")
     }
   }, [isLoggedIn])
+
+  // const [currentPage, setCurrentPage] = useState(1);
+  const { data: supplementsData, isLoading:isSuppLoading } = useQuery<SupplementResponse>({
+    queryKey: ["mypageSupps"],
+    queryFn: async () => {
+      const response = await axiosInstance.get(
+        `/mypage/supplements?page=1&category=${encodeURIComponent("전체")}`
+      );
+      console.log("mypage supp=", response.data);
+      return response.data;
+    },
+  });
+  if (isSuppLoading)
+    console.warn("마이페이지 영양제 로딩 중..");
+  const [supplements, setSupplements] = useState<SupplementResponse['result']['content']>([]);
+
+  useEffect(() => {
+    if (supplementsData?.result?.content) {
+      setSupplements(supplementsData.result.content);
+    }
+  }, [supplementsData]);
+
+  const handleBookmarkToggle = (id: number) => {
+    setSupplements(prev => prev.filter(supplement => supplement.id !== id));
+  };
 
   return (
     <div className="xl:w-[900px] xl:mx-auto lg:w-[900px] lg:mx-[50px] md:w-[601px] md:mx-auto w-[calc(100%-40px)] mx-5 py-8">
@@ -163,9 +236,21 @@ const MyPage: React.FC<MyPageProps> = ({
           </Link>
         </div>
         {supplements.length > 0 ? (
+        // {supplementsData?.result?.content && supplementsData.result.content.length > 0 ? (
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-            {supplements.map((supplement) => (
+            {/* {supplements.map((supplement) => (
               <SupplementCard key={supplement.id} {...supplement} />
+            ))} */}
+            {supplements.slice(0, 10).map((supplement) => (
+            // {supplementsData?.result.content.slice(0, 10).map((supplement) => (
+              <SupplementCard key={supplement.id}
+                              id={supplement.id}
+                              country={supplement.country}
+                              title={supplement.productName}
+                              tags={supplement.categories}
+                              isBookmarked={supplement.scrapped}
+                              src={supplement.image}
+                              onBookmarkToggle={handleBookmarkToggle}/>
             ))}
           </div>
         ) : (

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -32,6 +32,7 @@ interface PharmacyResponse {
       region: string;
       latitude: number;
       longitude: number;
+      isScrapped: boolean;
       place_id: string;
       img_url: string;
     }[];
@@ -150,13 +151,17 @@ const MyPage: React.FC<MyPageProps> = ({
   });
   if (isPharLoading)
     console.warn("마이페이지 약국 로딩 중..");
-  const [pharmacys, setPharmacys] = useState<PharmacyResponse['result']['pharmacies']>([]);
+  const [pharmacies, setPharmacies] = useState<PharmacyResponse['result']['pharmacies']>([]);
   
   useEffect(() => {
     if (pharmacyData?.result?.pharmacies) {
-      setPharmacys(pharmacyData.result.pharmacies);
+      setPharmacies(pharmacyData.result.pharmacies);
     }
   }, [pharmacyData]);
+
+  const handlePharmacyBookmarkToggle = (place_id: string) => {
+    setPharmacies(prev => prev.filter(pharmacy => pharmacy.place_id !== place_id));
+  };
   
   // const [currentPage, setCurrentPage] = useState(1);
   const { data: supplementsData, isLoading:isSuppLoading } = useQuery<SupplementResponse>({
@@ -249,10 +254,10 @@ const MyPage: React.FC<MyPageProps> = ({
             <ArrowRightIcon className="w-6 text-gray-500 h-4" />
           </Link>
         </div>
-        {pharmacys.length > 0 ? (
+        {pharmacies.length > 0 ? (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            {pharmacys.map((pharmacy) => (
-              <PharmacysCard key={pharmacy.place_id} {...pharmacy} />
+            {pharmacies.map((pharmacy) => (
+              <PharmacysCard key={pharmacy.place_id} {...pharmacy} onBookmarkToggle={handlePharmacyBookmarkToggle} />
             ))}
           </div>
         ) : (

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -15,14 +15,6 @@ interface Medicine {
   type: string;
 }
 
-// interface Pharmacy {
-//   id: number;
-//   pharmacyName: string;
-//   status: boolean;
-//   closingTime: string;
-//   distance: string;
-//   location: string;
-// }
 interface PharmacyResponse {
   code: string;
   message: string;
@@ -87,14 +79,6 @@ interface SupplementResponse {
   isSuccess: boolean;
 }
 
-// interface Supplement {
-//   id: number;
-//   country: string;
-//   title: string;
-//   tags: string[];
-//   isBookmarked: boolean;
-// }
-
 interface MyPageProps {
   userName: string;
   userEmail: string;
@@ -109,20 +93,6 @@ const MyPage: React.FC<MyPageProps> = ({
     { id: 1, name: "타이레놀", type: "진통제" },
     { id: 2, name: "판피린", type: "감기약" },
   ],
-  // pharmacys = [
-  //   { id: 1, pharmacyName: "온누리약국", status: true, closingTime: "19:00", distance: "700m", location: "서울 강남구 논현동" },
-  //   { id: 2, pharmacyName: "튼튼약국", status: false, closingTime: "17:00", distance: "600m", location: "서울 종로구 종로3가" },
-  //   { id: 3, pharmacyName: "온누리약국", status: true, closingTime: "19:00", distance: "700m", location: "서울 강남구 논현동" },
-  //   { id: 4, pharmacyName: "튼튼약국", status: false, closingTime: "17:00", distance: "600m", location: "서울 종로구 종로3가" },
-  // ],
-  // supplements = [
-  //   { id: 1, country: "미국", title: "네이처메이드", tags: ["면역력강화", "피부건강"], isBookmarked: true },
-  //   { id: 2, country: "한국", title: "홍삼정", tags: ["면역력", "활력"], isBookmarked: false },
-  //   { id: 3, country: "한국", title: "홍삼정", tags: ["면역력", "활력"], isBookmarked: false },
-  //   { id: 4, country: "미국", title: "네이처메이드", tags: ["면역력강화", "피부건강"], isBookmarked: true },
-  //   { id: 5, country: "한국", title: "홍삼정", tags: ["면역력", "활력"], isBookmarked: false },
-  //   { id: 6, country: "한국", title: "홍삼정", tags: ["면역력", "활력"], isBookmarked: false },
-  // ],
 }) => {
 
   const router = useRouter();

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -252,14 +252,7 @@ const MyPage: React.FC<MyPageProps> = ({
         {supplements.length > 0 ? (
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
             {supplements.slice(0, 10).map((supplement) => (
-              <SupplementCard key={supplement.id}
-                              id={supplement.id}
-                              country={supplement.country}
-                              title={supplement.productName}
-                              tags={supplement.categories}
-                              isBookmarked={supplement.scrapped}
-                              src={supplement.image}
-                              onBookmarkToggle={handleBookmarkToggle}/>
+              <SupplementCard key={supplement.id} {...supplement} src={supplement.image} onBookmarkToggle={handleBookmarkToggle}/>
             ))}
           </div>
         ) : (

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -15,13 +15,32 @@ interface Medicine {
   type: string;
 }
 
-interface Pharmacy {
-  id: number;
-  pharmacyName: string;
-  status: boolean;
-  closingTime: string;
-  distance: string;
-  location: string;
+// interface Pharmacy {
+//   id: number;
+//   pharmacyName: string;
+//   status: boolean;
+//   closingTime: string;
+//   distance: string;
+//   location: string;
+// }
+interface PharmacyResponse {
+  code: string;
+  message: string;
+  result: {
+    pharmacies: {
+      name: string;
+      region: string;
+      latitude: number;
+      longitude: number;
+      place_id: string;
+      img_url: string;
+    }[];
+    total_elements: number;
+    total_pages: number;
+    current_page: number;
+    elements_per_page: number;
+  };
+  isSuccess: boolean;
 }
 
 interface SupplementResponse {
@@ -79,7 +98,7 @@ interface MyPageProps {
   userName: string;
   userEmail: string;
   medicines?: Medicine[];
-  pharmacys?: Pharmacy[];
+  // pharmacys?: Pharmacy[];
   // supplements?: Supplement[];
 }
 
@@ -89,12 +108,12 @@ const MyPage: React.FC<MyPageProps> = ({
     { id: 1, name: "타이레놀", type: "진통제" },
     { id: 2, name: "판피린", type: "감기약" },
   ],
-  pharmacys = [
-    { id: 1, pharmacyName: "온누리약국", status: true, closingTime: "19:00", distance: "700m", location: "서울 강남구 논현동" },
-    { id: 2, pharmacyName: "튼튼약국", status: false, closingTime: "17:00", distance: "600m", location: "서울 종로구 종로3가" },
-    { id: 3, pharmacyName: "온누리약국", status: true, closingTime: "19:00", distance: "700m", location: "서울 강남구 논현동" },
-    { id: 4, pharmacyName: "튼튼약국", status: false, closingTime: "17:00", distance: "600m", location: "서울 종로구 종로3가" },
-  ],
+  // pharmacys = [
+  //   { id: 1, pharmacyName: "온누리약국", status: true, closingTime: "19:00", distance: "700m", location: "서울 강남구 논현동" },
+  //   { id: 2, pharmacyName: "튼튼약국", status: false, closingTime: "17:00", distance: "600m", location: "서울 종로구 종로3가" },
+  //   { id: 3, pharmacyName: "온누리약국", status: true, closingTime: "19:00", distance: "700m", location: "서울 강남구 논현동" },
+  //   { id: 4, pharmacyName: "튼튼약국", status: false, closingTime: "17:00", distance: "600m", location: "서울 종로구 종로3가" },
+  // ],
   // supplements = [
   //   { id: 1, country: "미국", title: "네이처메이드", tags: ["면역력강화", "피부건강"], isBookmarked: true },
   //   { id: 2, country: "한국", title: "홍삼정", tags: ["면역력", "활력"], isBookmarked: false },
@@ -119,6 +138,26 @@ const MyPage: React.FC<MyPageProps> = ({
     }
   }, [isLoggedIn])
 
+  const { data: pharmacyData, isLoading:isPharLoading } = useQuery<PharmacyResponse>({
+    queryKey: ["mypagePharmacys"],
+    queryFn: async () => {
+      const response = await axiosInstance.get(
+        `/mypage/pharmacy?country=ALL&page=1&size=4`
+      );
+      console.log("mypage pharmacy=", response.data);
+      return response.data;
+    },
+  });
+  if (isPharLoading)
+    console.warn("마이페이지 약국 로딩 중..");
+  const [pharmacys, setPharmacys] = useState<PharmacyResponse['result']['pharmacies']>([]);
+  
+  useEffect(() => {
+    if (pharmacyData?.result?.pharmacies) {
+      setPharmacys(pharmacyData.result.pharmacies);
+    }
+  }, [pharmacyData]);
+  
   // const [currentPage, setCurrentPage] = useState(1);
   const { data: supplementsData, isLoading:isSuppLoading } = useQuery<SupplementResponse>({
     queryKey: ["mypageSupps"],
@@ -213,7 +252,7 @@ const MyPage: React.FC<MyPageProps> = ({
         {pharmacys.length > 0 ? (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             {pharmacys.map((pharmacy) => (
-              <PharmacysCard key={pharmacy.id} {...pharmacy} />
+              <PharmacysCard key={pharmacy.place_id} {...pharmacy} />
             ))}
           </div>
         ) : (

--- a/src/pages/mypage/pharmacys/index.tsx
+++ b/src/pages/mypage/pharmacys/index.tsx
@@ -61,18 +61,6 @@ const MyPharmacys = () => {
     }
   }, [data, currentPage, refetch]);
 
-  const handleCountryFilter = (country: string) => {
-    setSelectedCountry(country);
-    setCurrentPage(1);
-  };
-
-  useEffect(() => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth' // 부드러운 스크롤 효과
-    });
-  }, [currentPage]);
-
   const displayData = data?.result;
   // const pharmacies = displayData?.pharmacies || [];
   const totalPages = displayData?.total_pages || 1;
@@ -88,6 +76,18 @@ const MyPharmacys = () => {
     });
     refetch(); // 데이터 새로고침
   };
+
+  const handleCountryFilter = (country: string) => {
+    setSelectedCountry(country);
+    setCurrentPage(1);
+  };
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth' // 부드러운 스크롤 효과
+    });
+  }, [currentPage]);
 
   return (
     <div className="xl:w-[900px] xl:mx-auto lg:w-[900px] lg:mx-[50px] md:w-[601px] md:mx-auto w-[calc(100%-40px)] mx-5 py-8 lg:py-9">

--- a/src/pages/mypage/pharmacys/index.tsx
+++ b/src/pages/mypage/pharmacys/index.tsx
@@ -66,6 +66,13 @@ const MyPharmacys = () => {
     setCurrentPage(1);
   };
 
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth' // 부드러운 스크롤 효과
+    });
+  }, [currentPage]);
+
   const displayData = data?.result;
   // const pharmacies = displayData?.pharmacies || [];
   const totalPages = displayData?.total_pages || 1;

--- a/src/pages/mypage/pharmacys/index.tsx
+++ b/src/pages/mypage/pharmacys/index.tsx
@@ -71,8 +71,8 @@ const MyPharmacys = () => {
           <div className="w-full">
             <div className="flex gap-2 overflow-x-auto lg:overflow-hidden w-full lg:w-auto flex-nowrap lg:flex-wrap scrollbar-hide">          
               <FilterButton text="전체" isSelected={selectedCountry === "ALL"} onClickFn={() => handleCountryFilter("ALL")} />
-              <FilterButton text="한국" isSelected={selectedCountry === "korea"} onClickFn={() => handleCountryFilter("korea")} />
-              <FilterButton text="미국" isSelected={selectedCountry === "usa"} onClickFn={() => handleCountryFilter("usa")}/>
+              <FilterButton text="한국" isSelected={selectedCountry === "KOREA"} onClickFn={() => handleCountryFilter("KOREA")} />
+              <FilterButton text="미국" isSelected={selectedCountry === "USA"} onClickFn={() => handleCountryFilter("USA")}/>
             </div>
           </div>
       </div>

--- a/src/pages/mypage/supplement/index.tsx
+++ b/src/pages/mypage/supplement/index.tsx
@@ -159,7 +159,7 @@ const SupplementPage: React.FC = () => {
           </div>
 
           {/* ✅ 페이지네이션 */}
-          <div className="flex items-center justify-center mt-6 space-x-3 py-10">
+          <div className="flex items-center justify-center mt-6 space-x-8 py-10">
             {Array.from({ length: totalPages }, (_, index) => (
               <button
                 key={index}

--- a/src/pages/mypage/supplement/index.tsx
+++ b/src/pages/mypage/supplement/index.tsx
@@ -116,6 +116,13 @@ const SupplementPage: React.FC = () => {
     setCurrentPage(1);
   };
 
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth' // 부드러운 스크롤 효과
+    });
+  }, [currentPage]);
+
   return (
     <div className="xl:w-[900px] xl:mx-auto lg:w-[900px] lg:mx-[50px] md:w-[601px] md:mx-auto w-[calc(100%-40px)] mx-5 py-8 lg:py-9">
       <div className="flex flex-col lg:flex-row items-start lg:items-center gap-3">

--- a/src/pages/mypage/supplement/index.tsx
+++ b/src/pages/mypage/supplement/index.tsx
@@ -154,13 +154,7 @@ const SupplementPage: React.FC = () => {
           <div className="w-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-y-5 py-5 lg:py-9">
             {supplements.map((supplement) => (
               <div key={supplement.id} onClick={() => handleCardClick(supplement.id)}>
-                <SupplementCard id={supplement.id}
-                                country={supplement.country}
-                                title={supplement.productName}
-                                tags={supplement.categories}
-                                isBookmarked={supplement.scrapped}
-                                src={supplement.image}
-                                onBookmarkToggle={handleBookmarkToggle}/>
+                <SupplementCard key={supplement.id} {...supplement} src={supplement.image} onBookmarkToggle={handleBookmarkToggle}/>
               </div>
             ))}
           </div>

--- a/src/pages/supplements/[supplementId]/index.tsx
+++ b/src/pages/supplements/[supplementId]/index.tsx
@@ -39,6 +39,7 @@ interface ApiResponse {
       brand: string;
       maker: string;
       categories: string[];
+      selectCategories: string[];
       scrapCount: number;
       scrapped: boolean;
     }[];

--- a/src/pages/supplements/[supplementId]/index.tsx
+++ b/src/pages/supplements/[supplementId]/index.tsx
@@ -87,7 +87,7 @@ const SupplementInfo: React.FC = () => {
   });
 
   if (isLoading)
-    console.error("영양제 상세 로딩 중..");
+    console.warn("영양제 상세 로딩 중..");
   if (isError)
     console.error("상세Error=", error);
 

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -51,8 +51,8 @@ interface Supplement {
 
 const SupplementPage: React.FC = () => {
   const router = useRouter();
-  const searchQuery = router.query.search as string || ""; // 검색어 가져오기
-  const country = router.query.country as string || ""; // "", "KOREA", "USA" 중 하나
+  const searchQuery = router.query.keyword as string || ""; // 검색어 가져오기
+  const country = router.query.country as string || ""; // "", "KOREA", "USA", "JAPAN" 중 하나
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedCategory, setSelectedCategory] = useState("전체");
   
@@ -83,12 +83,13 @@ const SupplementPage: React.FC = () => {
     setCurrentPage(1); // 카테고리 변경시 첫 페이지로 이동
   };
 
+  const countryParam = (country === "NONE" || country === "ALL") ? "" : country;
   const { data: searchData, isLoading: isSearchLoading, isError: isSearchError, error:searchError } = useQuery<SearchResponse>({
     queryKey: ["supplements-search", searchQuery, currentPage],
     // queryKey: ["supplements-search", "유산균", currentPage, ""],
     queryFn: async () => {
       const response = await axiosInstance.get(
-        `/supplements/search?keyword=${encodeURIComponent(searchQuery)}&country=${country}&page=${currentPage}`
+        `/supplements/search?keyword=${encodeURIComponent(searchQuery)}&country=${countryParam}&page=${currentPage}`
         // `/supplements/search?keyword=${encodeURIComponent("유산균")}&country=${""}&page=${currentPage}`
       
       );

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -168,12 +168,7 @@ const SupplementPage: React.FC = () => {
           <div className="w-full py-8 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-x-5 gap-y-5">
             {supplements.map((supplement) => (
               <div key={supplement.id} onClick={() => handleCardClick(supplement.id)}>
-                <SupplementCard id={supplement.id}
-                                country={supplement.country}
-                                title={supplement.productName}
-                                tags={supplement.categories}
-                                isBookmarked={supplement.scrapped}
-                                src={supplement.image}/>
+                <SupplementCard key={supplement.id} {...supplement} src={supplement.image}/>
               </div>
             ))}
           </div>

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import SupplementCard from "@/components/common/SupplementCard";
 import FilterButton from "@/components/common/FilterButton";
@@ -132,6 +132,14 @@ const SupplementPage: React.FC = () => {
   const handleCardClick = (id: number) => {
     router.push(`/supplements/${id}`);
   };
+
+  useEffect(() => {
+    // window.scrollTo(0, 0);
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth' // 부드러운 스크롤 효과
+    });
+  }, [currentPage]);
 
   return (
     <div className="xl:w-[900px] xl:mx-auto lg:w-[900px] lg:mx-[50px] md:w-[601px] md:mx-auto w-[calc(100%-40px)] mx-5 flex flex-col items-center py-8">

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -116,7 +116,7 @@ const SupplementPage: React.FC = () => {
   });
   
   if (isLoading || isSearchLoading)
-    console.error("영양제 로딩 중..");
+    console.warn("영양제 로딩 중..");
   if (isError)
     console.error("카테고리Error=", error);
   if (isSearchError)

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -51,7 +51,7 @@ interface Supplement {
 
 const SupplementPage: React.FC = () => {
   const router = useRouter();
-  const searchQuery = router.query.keyword as string || ""; // 검색어 가져오기
+  const searchQuery = router.query.search as string || ""; // 검색어 가져오기
   const country = router.query.country as string || ""; // "", "KOREA", "USA" 중 하나
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedCategory, setSelectedCategory] = useState("전체");
@@ -83,7 +83,7 @@ const SupplementPage: React.FC = () => {
     setCurrentPage(1); // 카테고리 변경시 첫 페이지로 이동
   };
 
-  const { data: searchData, isLoading: isSearchLoading, isError: isSearchError } = useQuery<SearchResponse>({
+  const { data: searchData, isLoading: isSearchLoading, isError: isSearchError, error:searchError } = useQuery<SearchResponse>({
     queryKey: ["supplements-search", searchQuery, currentPage],
     // queryKey: ["supplements-search", "유산균", currentPage, ""],
     queryFn: async () => {
@@ -109,7 +109,7 @@ const SupplementPage: React.FC = () => {
   if (isError)
     console.error("카테고리Error=", error);
   if (isSearchError)
-    console.error("isSearchError=", isSearchError);
+    console.error("isSearchError=", searchError);
 
   const displayData = searchQuery ? searchData?.result : data?.result;
   // const displayData = searchData?.result;

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -85,7 +85,7 @@ const SupplementPage: React.FC = () => {
 
   const countryParam = (country === "NONE" || country === "ALL") ? "" : country;
   const { data: searchData, isLoading: isSearchLoading, isError: isSearchError, error:searchError } = useQuery<SearchResponse>({
-    queryKey: ["supplements-search", searchQuery, currentPage],
+    queryKey: ["supplements-search", searchQuery, currentPage, countryParam],
     queryFn: async () => {
       try {
         const response = await axiosInstance.get(
@@ -115,7 +115,7 @@ const SupplementPage: React.FC = () => {
     enabled: router.isReady && Boolean(searchQuery)
   });
   // const { data: searchData, isLoading: isSearchLoading, isError: isSearchError, error:searchError } = useQuery<SearchResponse>({
-  //   queryKey: ["supplements-search", searchQuery, currentPage],
+  //   queryKey: ["supplements-search", searchQuery, currentPage, countryParam],
   //   queryFn: async () => {
   //     let retryCount = 0;
   //     const maxRetries = 10;

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -134,7 +134,6 @@ const SupplementPage: React.FC = () => {
   };
 
   useEffect(() => {
-    // window.scrollTo(0, 0);
     window.scrollTo({
       top: 0,
       behavior: 'smooth' // 부드러운 스크롤 효과

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -51,7 +51,7 @@ interface Supplement {
 
 const SupplementPage: React.FC = () => {
   const router = useRouter();
-  const searchQuery = router.query.search as string || ""; // 검색어 가져오기
+  const searchQuery = router.query.keyword as string || ""; // 검색어 가져오기
   const country = router.query.country as string || ""; // "", "KOREA", "USA" 중 하나
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedCategory, setSelectedCategory] = useState("전체");

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
 import SupplementCard from "@/components/common/SupplementCard";
 import FilterButton from "@/components/common/FilterButton";
@@ -47,6 +47,7 @@ interface Supplement {
   scrapCount: number;
   category4: string;
   categories: string[];
+  selectCategories: string[]; // 추가됨
   scrapped: boolean;
 }
 
@@ -76,8 +77,6 @@ const SupplementPage: React.FC = () => {
     staleTime: 0,
   });
 
-  console.log("검색어:", searchQuery);
-
   // 필터 버튼 클릭 핸들러
   const handleFilterClick = (category: string) => {
     setSelectedCategory(category);
@@ -92,6 +91,7 @@ const SupplementPage: React.FC = () => {
         const response = await axiosInstance.get(
           `/supplements/search?keyword=${encodeURIComponent(searchQuery)}&country=${countryParam}&page=${currentPage}`
         );
+        console.log(`검색어: ${searchQuery} 결과=`, response.data);
         return response.data;
       } catch (error) {
         // 404 에러인 경우 빈 결과를 반환
@@ -140,10 +140,27 @@ const SupplementPage: React.FC = () => {
     });
   }, [currentPage]);
 
+  // 검색 모드인지 확인
+  const isSearchMode = !!searchQuery;
+
+  // 표시할 영양제 목록 결정
+  const displaySupplements = useMemo(() => {
+    if (!isSearchMode) {
+      // 검색이 아닌 경우 기존 동작 유지
+      return supplements;
+    } else {
+      // 검색 결과인 경우 카테고리 필터링 적용
+      return supplements.filter(supplement => 
+        selectedCategory === "전체" || 
+        supplement.selectCategories?.includes(selectedCategory)
+      );
+    }
+  }, [isSearchMode, supplements, selectedCategory]);
+
   return (
     <div className="xl:w-[900px] xl:mx-auto lg:w-[900px] lg:mx-[50px] md:w-[601px] md:mx-auto w-[calc(100%-40px)] mx-5 flex flex-col items-center py-8">
       <div className="w-full max-w-[920px] flex items-center gap-x-4 mb-4 overflow-x-auto hidden lg:flex">
-        <h2 className="text-display2-b text-gray-600 whitespace-nowrap">{searchQuery ? `검색결과 ${displayData?.amountCount}건` : "전체"}</h2>
+        <h2 className="text-display2-b text-gray-600 whitespace-nowrap">{searchQuery ? `검색결과 ${displaySupplements.length}건` : "전체"}</h2>
         <div className="flex gap-x-2">
           <FilterButton text="전체" isSelected={selectedCategory === "전체"} onClickFn={() => handleFilterClick("전체")} />
           <FilterButton text="면역력강화" isSelected={selectedCategory === "면역"} onClickFn={() => handleFilterClick("면역")} />
@@ -156,7 +173,7 @@ const SupplementPage: React.FC = () => {
       </div>
 
       {/* ✅ 검색 결과가 없을 경우 메시지 표시 */}
-      {displayData?.amountCount === 0 ? (
+      {displaySupplements.length === 0 ? (
         <div className="flex justify-center items-center h-[300px]">
           <p className="text-gray-300 lg:text-headline-m md:text-m-body2-r text-center">
             찾는 영양제가 없으신가요?<br />철자를 확인하거나 다른 키워드로 검색해주세요!
@@ -166,7 +183,7 @@ const SupplementPage: React.FC = () => {
         <>
           {/* ✅ 검색 결과 리스트 */}
           <div className="w-full py-8 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-x-5 gap-y-5">
-            {supplements.map((supplement) => (
+            {displaySupplements.map((supplement) => (
               <div key={supplement.id} onClick={() => handleCardClick(supplement.id)}>
                 <SupplementCard key={supplement.id} {...supplement} src={supplement.image}/>
               </div>

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -201,11 +201,11 @@ const SupplementPage: React.FC = () => {
   }, [isSearchMode, supplements, selectedCategory]);
 
   useEffect(() => {
-    if (searchQuery) {
+    if (searchQuery || country) {
       setSelectedCategory("전체");
       setCurrentPage(1);
     }
-  }, [searchQuery]);
+  }, [searchQuery, country]);
 
   useEffect(() => {
     if (router.isReady) {

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -47,7 +47,7 @@ interface Supplement {
   scrapCount: number;
   category4: string;
   categories: string[];
-  selectCategories: string[]; // 추가됨
+  selectCategories: string[];
   scrapped: boolean;
 }
 
@@ -112,11 +112,54 @@ const SupplementPage: React.FC = () => {
         throw error;
       }
     },
-    enabled: !!searchQuery
+    enabled: router.isReady && Boolean(searchQuery)
   });
+  // const { data: searchData, isLoading: isSearchLoading, isError: isSearchError, error:searchError } = useQuery<SearchResponse>({
+  //   queryKey: ["supplements-search", searchQuery, currentPage],
+  //   queryFn: async () => {
+  //     let retryCount = 0;
+  //     const maxRetries = 10;
+
+  //     while (retryCount <= maxRetries) {
+  //       try {
+  //         const response = await axiosInstance.get(
+  //           `/supplements/search?keyword=${encodeURIComponent(searchQuery)}&country=${countryParam}&page=${currentPage}`
+  //         );
+  //         console.log(`검색어: ${searchQuery} 결과=`, response.data);
+  //         return response.data;
+  //       } catch (error) {
+  //         if (axios.isAxiosError(error) && error.response?.status === 404) {
+  //           if (retryCount === maxRetries) {
+  //             // 최대 재시도 횟수에 도달하면 빈 결과 반환
+  //             return {
+  //               code: "SUPP4001",
+  //               message: "검색 결과가 없습니다.",
+  //               result: {
+  //                 amountPage: 0,
+  //                 amountCount: 0,
+  //                 currentPage: 0,
+  //                 currentCount: 0,
+  //                 supplements: [],
+  //               },
+  //               isSuccess: false
+  //             };
+  //           }
+  //           // 재시도 전 1초 대기
+  //           await new Promise(resolve => setTimeout(resolve, 1000));
+  //           retryCount++;
+  //           continue;
+  //         }
+  //         throw error;
+  //       }
+  //     }
+  //   },
+  //   enabled: router.isReady && Boolean(searchQuery)
+  // });
   
-  if (isLoading || isSearchLoading)
-    console.warn("영양제 로딩 중..");
+  if (isLoading)
+    console.warn("카테고리 영양제 로딩 중..");
+  if (isSearchLoading)
+    console.warn("검색한 영양제 로딩 중..");
   if (isError)
     console.error("카테고리Error=", error);
   if (isSearchError)
@@ -156,6 +199,28 @@ const SupplementPage: React.FC = () => {
       );
     }
   }, [isSearchMode, supplements, selectedCategory]);
+
+  useEffect(() => {
+    if (searchQuery) {
+      setSelectedCategory("전체");
+      setCurrentPage(1);
+    }
+  }, [searchQuery]);
+
+  useEffect(() => {
+    if (router.isReady) {
+      console.log("Router Query:", router.query);
+      console.log("Search Query:", searchQuery);
+    }
+  }, [router.isReady, router.query, searchQuery]);
+
+  useEffect(() => {
+    // 페이지 진입 시 초기화
+    if (router.pathname === '/supplements' && !router.query.keyword) {
+      setSelectedCategory("전체");
+      setCurrentPage(1);
+    }
+  }, [router.pathname, router.query]);
 
   return (
     <div className="xl:w-[900px] xl:mx-auto lg:w-[900px] lg:mx-[50px] md:w-[601px] md:mx-auto w-[calc(100%-40px)] mx-5 flex flex-col items-center py-8">

--- a/src/pages/supplements/index.tsx
+++ b/src/pages/supplements/index.tsx
@@ -6,7 +6,6 @@ import { ArrowRightIcon } from "@public/svgs";
 import { axiosInstance } from "@/apis/axios-instance";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
-import { AxiosError } from 'axios';
 
 interface ApiResponse {
   code: string;
@@ -86,21 +85,6 @@ const SupplementPage: React.FC = () => {
   };
 
   const countryParam = (country === "NONE" || country === "ALL") ? "" : country;
-  // const { data: searchData, isLoading: isSearchLoading, isError: isSearchError, error:searchError } = useQuery<SearchResponse>({
-  //   queryKey: ["supplements-search", searchQuery, currentPage],
-  //   // queryKey: ["supplements-search", "유산균", currentPage, ""],
-  //   queryFn: async () => {
-  //     const response = await axiosInstance.get(
-  //       `/supplements/search?keyword=${encodeURIComponent(searchQuery)}&country=${countryParam}&page=${currentPage}`
-  //       // `/supplements/search?keyword=${encodeURIComponent("유산균")}&country=${""}&page=${currentPage}`
-      
-  //     );
-  //     console.log("search API Response:", response.data); // 데이터
-  //     return response.data;
-  //   },
-  //   enabled: !!searchQuery
-  //   // enabled:true
-  // });
   const { data: searchData, isLoading: isSearchLoading, isError: isSearchError, error:searchError } = useQuery<SearchResponse>({
     queryKey: ["supplements-search", searchQuery, currentPage],
     queryFn: async () => {


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) [feat/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #134


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
[마이페이지]
- 영양제 스크랩 카드 연결(마이페이지에서 최대 10개 보이게)
- 마이페이지 영양제 카드의 스크랩 클릭 시 즉시 카드 안 보이게
- 약국 스크랩 카드 연결(마이페이지에서 최대 4개 보이게)
- 마이페이지 약국 카드의 스크랩 클릭 시 즉시 안 보이게(반영함 but속도는 느림)
- >> 상비약 스크랩 기능 완료 시, 상비약 카드 연결(마이페이지에서 최대 4개 보이게)
- >> 상비약 스크랩 기능 완료 시, 마이페이지 상비약 카드의 스크랩 클릭 시 즉시 안 보이게 반영

[해외인기영양제 페이지]
- 검색어 받아오기
- 검색어 결과 보이게
- 검색 결과를 카테고리에 맞게 분류
- 1페이지가 아닌 다른 페이지에서 검색 시 검색 결과의 전체 카테고리의 1페이지로
- 검색 결과와 나라 즉시 반영
- 헤더 해외인기영양제 클릭 시 전체 목록 보이도록
- >> japan 추가됨 근데 이거 검색창 수정? 요청? 근데 전체 영양제에서 [일본]을 아직 못 봤음
- 페이지 선택 시 부드럽게 스크롤 추가

[해외인기영양제 스크랩 페이지] ->>> 완료
- 페이지 간격 수정
- 영양제 스크랩 목록(페이지네이션 연결)
- 목록 페이지에서 스크랩 클릭 시 즉시 카드 안 보이게
- 페이지 선택 시 부드럽게 스크롤 추가

[약국 스크랩 페이지]->>> 완료(but속도는 느림 다음 백 배포 때 속도 개선될 예정) --> 속도 개선됨
- 카드 보이게 함
- 약국 스크랩 목록(페이지네이션 연결)
- 스크랩 클릭 시 즉시 안 보이게
- 페이지 선택 시 부드럽게 스크롤 추가

[상비약 스크랩 페이지]
- >> 노션api명세서에 FE 상비약 스크랩 수정 중이라고 되어있음. 구현되면 추가
- >> 상비약 스크랩 목록(페이지네이션 연결)
- >> 스크랩 클릭 시 즉시 안 보이게 반영은 상비약api 응답에 scrapped 여부 추가(BE요청) 후 수정
- >> 페이지 선택 시 부드럽게 스크롤 추가

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## 💬 리뷰 요구사항(선택)
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?-->
